### PR TITLE
Add InsecureSkipVerify to ignore etcd ssl warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Usage of ./butler:
   -test
         Are we testing butler? (probably not!)
   -tls.insecure-skip-verify
-        Disable SSL verification.
+        Disable SSL verification for etcd and https.
   -version
         Print version information.
 

--- a/README.md
+++ b/README.md
@@ -23,35 +23,38 @@ There are various ways that you can run butler. We will ultimately deploy butler
 ### Command Line Usage
 ```
 [16:06]pts/22:49(stegen@woden):[~]%
+./butler -h
 Usage of ./butler:
   -config.path string
-    	Full remote path to butler configuration file (eg: full URL scheme://path).
+        Full remote path to butler configuration file (eg: full URL scheme://path).
   -config.retrieve-interval string
-    	The interval, in seconds, to retrieve new butler configuration files. (default "300")
+        The interval, in seconds, to retrieve new butler configuration files. (default "300")
   -etcd.endpoints string
-    	The endpoints to connect to etcd.
+        The endpoints to connect to etcd.
   -http.auth_token string
-    	HTTP auth token to use for HTTP authentication.
+        HTTP auth token to use for HTTP authentication.
   -http.auth_type string
-    	HTTP auth type (eg: basic / digest / token-key) to use. If empty (by default) do not use HTTP authentication.
+        HTTP auth type (eg: basic / digest / token-key) to use. If empty (by default) do not use HTTP authentication.
   -http.auth_user string
-    	HTTP auth user to use for HTTP authentication
+        HTTP auth user to use for HTTP authentication
   -http.retries string
-    	The number of http retries for GET requests to obtain the butler configuration files (default "4")
+        The number of http retries for GET requests to obtain the butler configuration files (default "5")
   -http.retry_wait_max string
-    	The maximum amount of time to wait before attemping to retry the http config get operation. (default "10")
+        The maximum amount of time to wait before attemping to retry the http config get operation. (default "15")
   -http.retry_wait_min string
-    	The minimum amount of time to wait before attemping to retry the http config get operation. (default "5")
+        The minimum amount of time to wait before attemping to retry the http config get operation. (default "5")
   -http.timeout string
-    	The http timeout, in seconds, for GET requests to obtain the butler configuration file. (default "10")
+        The http timeout, in seconds, for GET requests to obtain the butler configuration file. (default "10")
   -log.level string
-    	The butler log level. Log levels are: debug, info, warn, error, fatal, panic. (default "info")
+        The butler log level. Log levels are: debug, info, warn, error, fatal, panic. (default "info")
   -s3.region string
-    	The S3 Region that the config file resides.
+        The S3 Region that the config file resides.
   -test
-    	Are we testing butler? (probably not!)
+        Are we testing butler? (probably not!)
+  -tls.insecure-skip-verify
+        Disable SSL verification.
   -version
-    	Print version information.
+        Print version information.
 
 [16:08]pts/22:50(stegen@woden):[~]%
 

--- a/README.md
+++ b/README.md
@@ -475,12 +475,12 @@ butler_localconfig_render_time 1.501070527e+09
 butler_remoterepo_config_valid{config_file="commonalerts.yml"} 1
 butler_remoterepo_config_valid{config_file="prometheus.yml"} 1
 butler_remoterepo_config_valid{config_file="tenant.yml"} 1
-# HELP butler_remoterepo_contact_success Did butler succesfully contact the remote repository
+# HELP butler_remoterepo_contact_success Did butler successfully contact the remote repository
 # TYPE butler_remoterepo_contact_success gauge
 butler_remoterepo_contact_success{config_file="commonalerts.yml"} 1
 butler_remoterepo_contact_success{config_file="prometheus.yml"} 1
 butler_remoterepo_contact_success{config_file="tenant.yml"} 1
-# HELP butler_remoterepo_contact_time Time that butler succesfully contacted the remote repository
+# HELP butler_remoterepo_contact_time Time that butler successfully contacted the remote repository
 # TYPE butler_remoterepo_contact_time gauge
 butler_remoterepo_contact_time{config_file="commonalerts.yml"} 1.501070685e+09
 butler_remoterepo_contact_time{config_file="prometheus.yml"} 1.501070697e+09

--- a/cmd/butler/main.go
+++ b/cmd/butler/main.go
@@ -68,21 +68,22 @@ func SetLogLevel(l string) log.Level {
 
 func main() {
 	var (
-		err                    error
-		versionFlag            = flag.Bool("version", false, "Print version information.")
-		configPath             = flag.String("config.path", "", "Full remote path to butler configuration file (eg: full URL scheme://path).")
-		configInterval         = flag.String("config.retrieve-interval", fmt.Sprintf("%v", defaultButlerConfigInterval), "The interval, in seconds, to retrieve new butler configuration files.")
-		configHTTPTimeout      = flag.String("http.timeout", fmt.Sprintf("%v", defaultHTTPTimeout), "The http timeout, in seconds, for GET requests to obtain the butler configuration file.")
-		configHTTPRetries      = flag.String("http.retries", fmt.Sprintf("%v", defaultHTTPRetries), "The number of http retries for GET requests to obtain the butler configuration files")
-		configHTTPRetryWaitMin = flag.String("http.retry_wait_min", fmt.Sprintf("%v", defaultHTTPRetryWaitMin), "The minimum amount of time to wait before attemping to retry the http config get operation.")
-		configHTTPRetryWaitMax = flag.String("http.retry_wait_max", fmt.Sprintf("%v", defaultHTTPRetryWaitMax), "The maximum amount of time to wait before attemping to retry the http config get operation.")
-		configHTTPAuthToken    = flag.String("http.auth_token", "", "HTTP auth token to use for HTTP authentication.")
-		configHTTPAuthType     = flag.String("http.auth_type", "", "HTTP auth type (eg: basic / digest / token-key) to use. If empty (by default) do not use HTTP authentication.")
-		configHTTPAuthUser     = flag.String("http.auth_user", "", "HTTP auth user to use for HTTP authentication")
-		configS3Region         = flag.String("s3.region", "", "The S3 Region that the config file resides.")
-		configEtcdEndpoints    = flag.String("etcd.endpoints", "", "The endpoints to connect to etcd.")
-		configLogLevel         = flag.String("log.level", "info", "The butler log level. Log levels are: debug, info, warn, error, fatal, panic.")
-		butlerTest             = flag.Bool("test", false, "Are we testing butler? (probably not!)")
+		err                         error
+		versionFlag                 = flag.Bool("version", false, "Print version information.")
+		configPath                  = flag.String("config.path", "", "Full remote path to butler configuration file (eg: full URL scheme://path).")
+		configInterval              = flag.String("config.retrieve-interval", fmt.Sprintf("%v", defaultButlerConfigInterval), "The interval, in seconds, to retrieve new butler configuration files.")
+		configHTTPTimeout           = flag.String("http.timeout", fmt.Sprintf("%v", defaultHTTPTimeout), "The http timeout, in seconds, for GET requests to obtain the butler configuration file.")
+		configHTTPRetries           = flag.String("http.retries", fmt.Sprintf("%v", defaultHTTPRetries), "The number of http retries for GET requests to obtain the butler configuration files")
+		configHTTPRetryWaitMin      = flag.String("http.retry_wait_min", fmt.Sprintf("%v", defaultHTTPRetryWaitMin), "The minimum amount of time to wait before attemping to retry the http config get operation.")
+		configHTTPRetryWaitMax      = flag.String("http.retry_wait_max", fmt.Sprintf("%v", defaultHTTPRetryWaitMax), "The maximum amount of time to wait before attemping to retry the http config get operation.")
+		configHTTPAuthToken         = flag.String("http.auth_token", "", "HTTP auth token to use for HTTP authentication.")
+		configHTTPAuthType          = flag.String("http.auth_type", "", "HTTP auth type (eg: basic / digest / token-key) to use. If empty (by default) do not use HTTP authentication.")
+		configHTTPAuthUser          = flag.String("http.auth_user", "", "HTTP auth user to use for HTTP authentication")
+		configS3Region              = flag.String("s3.region", "", "The S3 Region that the config file resides.")
+		configEtcdEndpoints         = flag.String("etcd.endpoints", "", "The endpoints to connect to etcd.")
+		configTlsInsecureSkipVerify = flag.Bool("tls.insecure-skip-verify", false, "Disable SSL verification.")
+		configLogLevel              = flag.String("log.level", "info", "The butler log level. Log levels are: debug, info, warn, error, fatal, panic.")
+		butlerTest                  = flag.Bool("test", false, "Are we testing butler? (probably not!)")
 	)
 	flag.Parse()
 	newConfigLogLevel := environment.GetVar(*configLogLevel)
@@ -167,6 +168,7 @@ func main() {
 		log.Debugf("main(): setting RetryWaitMin[%d] and RetryWaitMax[%d]", newConfigHTTPRetryWaitMin, newConfigHTTPRetryWaitMax)
 		bc.SetRetryWaitMin(newConfigHTTPRetryWaitMin)
 		bc.SetRetryWaitMax(newConfigHTTPRetryWaitMax)
+		bc.InsecureSkipVerify = *configTlsInsecureSkipVerify
 	case "s3", "S3":
 		if *configS3Region == "" {
 			log.Fatalf("You must provide a -s3.region for use with the s3 downloader.")
@@ -183,6 +185,7 @@ func main() {
 		newConfigEtcdEndpoints := environment.GetVar(*configEtcdEndpoints)
 		log.Debugf("main(): setting etcd endpoints=%v", newConfigEtcdEndpoints)
 		bc.SetEndpoints(strings.Split(newConfigEtcdEndpoints, ","))
+		bc.InsecureSkipVerify = *configTlsInsecureSkipVerify
 	}
 
 	// Set the butler configuration retrieval interval

--- a/cmd/butler/main.go
+++ b/cmd/butler/main.go
@@ -81,7 +81,7 @@ func main() {
 		configHTTPAuthUser          = flag.String("http.auth_user", "", "HTTP auth user to use for HTTP authentication")
 		configS3Region              = flag.String("s3.region", "", "The S3 Region that the config file resides.")
 		configEtcdEndpoints         = flag.String("etcd.endpoints", "", "The endpoints to connect to etcd.")
-		configTlsInsecureSkipVerify = flag.Bool("tls.insecure-skip-verify", false, "Disable SSL verification.")
+		configTlsInsecureSkipVerify = flag.Bool("tls.insecure-skip-verify", false, "Disable SSL verification for etcd and https.")
 		configLogLevel              = flag.String("log.level", "info", "The butler log level. Log levels are: debug, info, warn, error, fatal, panic.")
 		butlerTest                  = flag.Bool("test", false, "Are we testing butler? (probably not!)")
 	)

--- a/contrib/butler.toml.etcdtest
+++ b/contrib/butler.toml.etcdtest
@@ -88,6 +88,9 @@ title = "Butler Configuration"
     ## These are repo specific http get options
     [prometheus.prom.yml.etcd]
       endpoints = "http://127.0.0.1:2379"
+      # If you have self signed certs for etcd, you may need
+      # to skip ssl verification. Default value is "false".
+      insecure-skip-verify = "false"
 
   ## These are the options for reloading the alertmanager config-handler
   [prometheus.reloader]

--- a/contrib/butler.toml.sample
+++ b/contrib/butler.toml.sample
@@ -203,7 +203,7 @@ title = "Butler Configuration"
   ## These are the definitions for the first repo which is defined for alertmanager
   [alertmanager.repo3.domain.com]
     ## Method can be file, http, https, or s3. In the future it will support Azure blob
-    method = "http"
+    method = "https"
 
     ## Path is the URI / Path to the file on the repo
     repo-path = "/butler/configs/alertmanager"
@@ -215,11 +215,15 @@ title = "Butler Configuration"
     #additional-config = ["alerts/butler.yml", "rules/commonrules.yml"]
 
     ## These are repo specific http get options
-    [alertmanager.repo3.domain.com.http]
+    [alertmanager.repo3.domain.com.https]
       retries = "5"
       retry-wait-min = "5"
       retry-wait-max = "10"
       timeout = "10"
+      # If you are using a self signed cert and wish to connect insecurely
+      # over http, set the following insecure-skip-verify flag to "true"
+      # The default value is "false"
+      insecure-skip-verify = "false"
 
   ## This will be processed second (and appended / replaced depending)
   [alertmanager.repo4.domain.com]

--- a/internal/config/handler.go
+++ b/internal/config/handler.go
@@ -50,9 +50,10 @@ type ButlerConfig struct {
 	HTTPAuthUser  string
 	HTTPAuthToken string
 	// some s3 specific stuff
-	S3Region  string
-	S3Bucket  string
-	Endpoints []string
+	S3Region           string
+	S3Bucket           string
+	Endpoints          []string
+	InsecureSkipVerify bool
 }
 
 var (
@@ -248,7 +249,7 @@ func (bc *ButlerConfig) Init() error {
 			return err
 		}
 	case "etcd":
-		client.Method, err = methods.NewEtcdMethodWithEndpoints(bc.Endpoints)
+		client.Method, err = methods.NewEtcdMethodWithEndpoints(bc.Endpoints, bc.InsecureSkipVerify)
 		if err != nil {
 			return err
 		}

--- a/internal/config/handler.go
+++ b/internal/config/handler.go
@@ -229,6 +229,7 @@ func (bc *ButlerConfig) Init() error {
 		m.AuthType = bc.HTTPAuthType
 		m.AuthToken = bc.HTTPAuthToken
 		m.AuthUser = bc.HTTPAuthUser
+		m.InsecureSkipVerify = bc.InsecureSkipVerify
 		client.Method = m
 	case "s3", "S3":
 		pathSplit := strings.Split(bc.URL.Path, "/")


### PR DESCRIPTION
Etcd can be running with invalid certificate. it has a mode called "auto-tls" which provides self signed certificates out of the box.

https://coreos.com/etcd/docs/latest/op-guide/security.html

Do you agree with the approach? 