### PR TITLE
Tidying up how we're handling the different methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO:=go
 pkgs=$(shell $(GO) list ./... | egrep -v "(vendor)")
 
 export DOCKERHUB_USER=$(shell echo "$$DOCKERHUB_USER")
-export BUTLER_VERSION=1.3.0
+export BUTLER_VERSION=1.4.0
 export VERSION=v$(BUTLER_VERSION)
 
 default: ci

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,12 @@ help:
 	@printf "make test-accept\t\tRuns acceptance testing.\n"
 	@printf "make test-unit\t\t\tRuns unit testing.\n"
 	@printf "make run\t\t\tRun butler on local system.\n"
+	@printf "make start-etcd\t\t\tRun a local etcd instance for testing.\n"
 	@printf "make start-alertmanager\t\tRun a local alertmanager instance for testing.\n"
 	@printf "make start-prometheus\t\tRun a local prometheus v1 instance for testing.\n"
 	@printf "make start-prometheus2\t\tRun a local prometheus v2 instance for testing.\n"
 	@printf "make start-am-prom\t\tRun a local alertmanager and prometheus instance for testing.\n"
+	@printf "make stop-etcd\t\t\tStop the local etcd instance for testing.\n"
 	@printf "make stop-alertmanager\t\tStop the local test alertmanager instance.\n"
 	@printf "make stop-prometheus\t\tStop the local test prometheus instance.\n"
 	@printf "make stop-am-prom\t\tStop the local test alertmanager and prometheus instance.\n"
@@ -110,6 +112,9 @@ help:
 
 run:
 	$(GO) run -ldflags "-X main.version=$(VERSION)" cmd/butler/main.go -config.path http://localhost/butler/config/butler.toml -config.retrieve-interval 10 -log.level debug
+
+start-etcd:
+	@docker run --rm -it --name=etcd -d -p 4001:4001 -p 2379:2379 -p 2380:2380 -v /tmp:/tmp quay.io/coreos/etcd:v3.2.17 etcd --name etcd --initial-cluster-state new --advertise-client-urls http://127.0.0.1:2379,http://127.0.0.1:4001 --listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 --initial-cluster-token etcd-cluster-1 --initial-cluster etcd=http://127.0.0.1:2380 --initial-advertise-peer-urls http://127.0.0.1:2380
 
 start-prometheus:
 	@docker run --rm -it --name=prometheus -d -p 9090:9090 -v /opt/prometheus:/etc/prometheus prom/prometheus:v1.8.2 -config.file=/etc/prometheus/prometheus.yml -storage.local.path=/prometheus -storage.local.memory-chunks=104857
@@ -123,6 +128,9 @@ start-alertmanager:
 start-am-prom: start-prometheus start-alertmanager
 #	@docker run --rm -it --name=prometheus -d -p 9090:9090 -v /opt/prometheus:/etc/prometheus prom/prometheus -config.file=/etc/prometheus/prometheus.yml -storage.local.path=/prometheus -storage.local.memory-chunks=104857
 #	@docker run --rm -it --name=alertmanager -d -p 9093:9093 -v /opt/alertmanager:/etc/alertmanager prom/alertmanager -config.file=/etc/alertmanager/alertmanager.yml
+
+stop-etcd:
+	@docker stop etcd
 
 stop-prometheus:
 	@docker stop prometheus

--- a/cmd/butler/main.go
+++ b/cmd/butler/main.go
@@ -113,17 +113,19 @@ func main() {
 		log.Fatalf("Cannot properly parse -config.path. -config.path must be in URL form. -config.path=%v", environment.GetVar(*configPath))
 	}
 
-	bc := config.NewButlerConfig()
-	bc.URL = newURL
-	bc.SetLogLevel(SetLogLevel(newConfigLogLevel))
-	err = bc.SetScheme(bc.URL.Scheme)
-	if err != nil {
-		log.Fatalf("Unsupported butler scheme. scheme=%v", bc.URL.Scheme)
+	opts := &config.ButlerConfigOpts{
+		InsecureSkipVerify: *configTlsInsecureSkipVerify,
+		LogLevel:           SetLogLevel(newConfigLogLevel),
+		URL:                newURL,
 	}
-	bc.SetPath(bc.URL.Path)
+	bc, err := config.NewButlerConfig(opts)
+	if err != nil {
+		log.Fatalf("Unsupported butler scheme. scheme=%v", bc.Scheme())
+	}
 
-	switch bc.URL.Scheme {
+	switch bc.Scheme() {
 	case "http", "https":
+		opts := config.HttpMethodOpts{Scheme: bc.Scheme()}
 		newConfigHTTPAuthType := strings.ToLower(environment.GetVar(*configHTTPAuthType))
 		if newConfigHTTPAuthType != "" {
 			if environment.GetVar(*configHTTPAuthUser) != "" && environment.GetVar(*configHTTPAuthToken) != "" {
@@ -132,9 +134,12 @@ func main() {
 			}
 			switch newConfigHTTPAuthType {
 			case "basic", "digest", "token-key":
-				bc.SetHTTPAuthType(newConfigHTTPAuthType)
-				bc.SetHTTPAuthToken(*configHTTPAuthToken)
-				bc.SetHTTPAuthUser(*configHTTPAuthUser)
+				opts.HTTPAuthType = newConfigHTTPAuthType
+				opts.HTTPAuthToken = *configHTTPAuthToken
+				opts.HTTPAuthUser = *configHTTPAuthUser
+				//bc.SetHTTPAuthType(newConfigHTTPAuthType)
+				//bc.SetHTTPAuthToken(*configHTTPAuthToken)
+				//bc.SetHTTPAuthUser(*configHTTPAuthUser)
 				break
 			default:
 				log.Fatalf("Unsupported HTTP Authentication Type: %s", newConfigHTTPAuthType)
@@ -146,7 +151,7 @@ func main() {
 			newConfigHTTPTimeout = defaultHTTPTimeout
 		}
 		log.Debugf("main(): setting HttpTimeout to %d", newConfigHTTPTimeout)
-		bc.SetTimeout(newConfigHTTPTimeout)
+		opts.Timeout = newConfigHTTPTimeout
 
 		// Set the HTTP Retries Counter
 		newConfigHTTPRetries, _ := strconv.Atoi(environment.GetVar(*configHTTPRetries))
@@ -154,7 +159,7 @@ func main() {
 			newConfigHTTPRetries = defaultHTTPRetries
 		}
 		log.Debugf("main(): setting HttpRetries to %d", newConfigHTTPRetries)
-		bc.SetRetries(newConfigHTTPRetries)
+		opts.Retries = newConfigHTTPRetries
 
 		// Set the HTTP Holdoff Values
 		newConfigHTTPRetryWaitMin, _ := strconv.Atoi(environment.GetVar(*configHTTPRetryWaitMin))
@@ -166,26 +171,39 @@ func main() {
 			newConfigHTTPRetryWaitMax = defaultHTTPRetryWaitMax
 		}
 		log.Debugf("main(): setting RetryWaitMin[%d] and RetryWaitMax[%d]", newConfigHTTPRetryWaitMin, newConfigHTTPRetryWaitMax)
-		bc.SetRetryWaitMin(newConfigHTTPRetryWaitMin)
-		bc.SetRetryWaitMax(newConfigHTTPRetryWaitMax)
-		bc.InsecureSkipVerify = *configTlsInsecureSkipVerify
-	case "s3", "S3":
+		opts.RetryWaitMin = newConfigHTTPRetryWaitMin
+		opts.RetryWaitMax = newConfigHTTPRetryWaitMax
+		bc.SetMethodOpts(opts)
+	case "s3":
+		opts := config.S3MethodOpts{Scheme: bc.Scheme()}
 		if *configS3Region == "" {
 			log.Fatalf("You must provide a -s3.region for use with the s3 downloader.")
 		}
 		newConfigS3Region := environment.GetVar(*configS3Region)
 		log.Debugf("main(): setting s3 region=%v", newConfigS3Region)
-		bc.SetRegion(newConfigS3Region)
+		opts.Region = newConfigS3Region
+		pathSplit := strings.Split(bc.Path(), "/")[0]
+		opts.Bucket = pathSplit
+		bc.SetMethodOpts(opts)
 	case "blob":
-		os.Setenv("BUTLER_STORAGE_ACCOUNT", bc.URL.Host)
+		opts := config.BlobMethodOpts{Scheme: bc.Scheme()}
+		os.Setenv("BUTLER_STORAGE_ACCOUNT", bc.Host())
+		bc.SetMethodOpts(opts)
 	case "etcd":
+		opts := config.EtcdMethodOpts{Scheme: bc.Scheme()}
 		if *configEtcdEndpoints == "" {
 			log.Fatalf("You must provide a valid -etcd.endpoints for use with the etcd downloader.")
 		}
 		newConfigEtcdEndpoints := environment.GetVar(*configEtcdEndpoints)
 		log.Debugf("main(): setting etcd endpoints=%v", newConfigEtcdEndpoints)
-		bc.SetEndpoints(strings.Split(newConfigEtcdEndpoints, ","))
-		bc.InsecureSkipVerify = *configTlsInsecureSkipVerify
+		opts.Endpoints = strings.Split(newConfigEtcdEndpoints, ",")
+		bc.SetMethodOpts(opts)
+	case "file":
+		opts := config.FileMethodOpts{Scheme: bc.Scheme()}
+		bc.SetMethodOpts(opts)
+	default:
+		opts := config.GenericMethodOpts{Scheme: bc.Scheme()}
+		bc.SetMethodOpts(opts)
 	}
 
 	// Set the butler configuration retrieval interval
@@ -213,7 +231,6 @@ func main() {
 			if butlerTesting {
 				log.Fatalf("Cannot retrieve butler configuration. err=%s butlerTesting=%#v", err.Error(), butlerTesting)
 			}
-			//log.Error("Cannot retrieve butler configuration. err=%s", err.Error())
 			log.Warnf("main(): Sleeping 5 seconds.")
 			time.Sleep(5 * time.Second)
 		} else {

--- a/cmd/butler/main.go
+++ b/cmd/butler/main.go
@@ -183,8 +183,9 @@ func main() {
 		opts.Bucket = pathSplit
 		bc.SetMethodOpts(opts)
 	case "blob":
-		opts := config.BlobMethodOpts{Scheme: bc.Scheme()}
-		os.Setenv("BUTLER_STORAGE_ACCOUNT", bc.Host())
+		opts := config.BlobMethodOpts{Scheme: bc.Scheme(),
+			AccountName: bc.Host(),
+			AccountKey:  os.Getenv("ACCOUNT_KEY")}
 		bc.SetMethodOpts(opts)
 	case "etcd":
 		u := bc.URL()

--- a/cmd/butler/main.go
+++ b/cmd/butler/main.go
@@ -137,9 +137,6 @@ func main() {
 				opts.HTTPAuthType = newConfigHTTPAuthType
 				opts.HTTPAuthToken = *configHTTPAuthToken
 				opts.HTTPAuthUser = *configHTTPAuthUser
-				//bc.SetHTTPAuthType(newConfigHTTPAuthType)
-				//bc.SetHTTPAuthToken(*configHTTPAuthToken)
-				//bc.SetHTTPAuthUser(*configHTTPAuthUser)
 				break
 			default:
 				log.Fatalf("Unsupported HTTP Authentication Type: %s", newConfigHTTPAuthType)

--- a/cmd/butler/main.go
+++ b/cmd/butler/main.go
@@ -187,6 +187,10 @@ func main() {
 		os.Setenv("BUTLER_STORAGE_ACCOUNT", bc.Host())
 		bc.SetMethodOpts(opts)
 	case "etcd":
+		u := bc.URL()
+		newU := fmt.Sprintf("%v://%v/%v%v", u.Scheme, u.Host, u.Host, u.Path)
+		rewriteURL, _ := url.Parse(newU)
+		bc.SetURL(rewriteURL)
 		opts := config.EtcdMethodOpts{Scheme: bc.Scheme()}
 		if *configEtcdEndpoints == "" {
 			log.Fatalf("You must provide a valid -etcd.endpoints for use with the etcd downloader.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,7 @@ func (c *ConfigSettings) ParseConfig(config []byte) error {
 	var (
 		Config  ConfigSettings
 		Globals ConfigGlobals
+		path    string
 	)
 	log.Debugf("ConfigSettings::ParseConfig(): entering.")
 	// The  configuration is in TOML format
@@ -231,7 +232,13 @@ func (c *ConfigSettings) ParseConfig(config []byte) error {
 		for _, u := range m.Repos {
 			opts := fmt.Sprintf("%s.%s", m.Name, u)
 			m.ManagerOpts[opts].SetParentManager(m.Name)
-			baseRemotePath := fmt.Sprintf("%s://%s%s", m.ManagerOpts[opts].Method, u, m.ManagerOpts[opts].RepoPath)
+			repo := strings.Replace(u, "/", "", -1)
+			if strings.HasPrefix(m.ManagerOpts[opts].RepoPath, "/") {
+				path = strings.Replace(m.ManagerOpts[opts].RepoPath, "/", "", 1)
+			} else {
+				path = m.ManagerOpts[opts].RepoPath
+			}
+			baseRemotePath := fmt.Sprintf("%s://%s/%s", m.ManagerOpts[opts].Method, repo, path)
 			for _, f := range m.ManagerOpts[opts].PrimaryConfig {
 				fullRemotePath := fmt.Sprintf("%s/%s", baseRemotePath, f)
 				m.ManagerOpts[opts].AppendPrimaryConfigURL(fullRemotePath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,12 @@ const (
 	butlerFooter = "#butlerend"
 )
 
+type ButlerConfigOpts struct {
+	InsecureSkipVerify bool
+	LogLevel           log.Level
+	URL                *url.URL
+}
+
 type ConfigClient struct {
 	Scheme     string
 	Method     methods.Method
@@ -84,10 +90,9 @@ func (c *ConfigClient) Get(val *url.URL) (*methods.Response, error) {
 		response *methods.Response
 		err      error
 	)
-	switch val.Scheme {
-	case "blob", "file", "http", "https", "s3", "S3", "etcd":
+	if IsValidScheme(val.Scheme) {
 		response, err = c.Method.Get(val)
-	default:
+	} else {
 		response = &methods.Response{}
 		err = errors.New("unsupported scheme")
 	}

--- a/internal/config/handler.go
+++ b/internal/config/handler.go
@@ -107,6 +107,10 @@ func (bc *ButlerConfig) URL() *url.URL {
 	return bc.url
 }
 
+func (bc *ButlerConfig) SetURL(u *url.URL) {
+	bc.url = u
+}
+
 func (bc *ButlerConfig) Opts() MethodOpts {
 	return bc.MethodOpts
 }

--- a/internal/config/handler.go
+++ b/internal/config/handler.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/adobe/butler/internal/methods"
+	//"github.com/adobe/butler/internal/methods"
 	"github.com/adobe/butler/internal/metrics"
 	"github.com/adobe/butler/internal/reloaders"
 
@@ -32,7 +32,7 @@ import (
 )
 
 type ButlerConfig struct {
-	URL                     *url.URL
+	url                     *url.URL
 	Client                  *ConfigClient
 	Config                  *ConfigSettings
 	FirstRun                bool
@@ -41,19 +41,20 @@ type ButlerConfig struct {
 	Interval                int
 	Timeout                 int
 	RawConfig               []byte
-	Retries                 int
-	RetryWaitMin            int
-	RetryWaitMax            int
-	Scheduler               *gocron.Scheduler
+	//Retries                 int
+	//RetryWaitMin            int
+	//RetryWaitMax            int
+	Scheduler *gocron.Scheduler
 	// some http specific stuff
-	HTTPAuthType  string
-	HTTPAuthUser  string
-	HTTPAuthToken string
+	//HTTPAuthType  string
+	//HTTPAuthUser  string
+	//HTTPAuthToken string
 	// some s3 specific stuff
-	S3Region           string
-	S3Bucket           string
-	Endpoints          []string
+	//S3Region           string
+	//S3Bucket           string
+	//Endpoints          []string
 	InsecureSkipVerify bool
+	MethodOpts         MethodOpts
 }
 
 var (
@@ -72,20 +73,42 @@ func (bc *ButlerConfig) SetScheme(s string) error {
 		res = errors.New(errMsg)
 	} else {
 		log.Debugf("Config::SetScheme(): setting bc.Scheme=%s", scheme)
-		bc.URL.Scheme = scheme
+		bc.url.Scheme = scheme
 	}
 	return res
+}
+
+func (bc *ButlerConfig) Scheme() string {
+	return bc.url.Scheme
 }
 
 func (bc *ButlerConfig) SetPath(p string) error {
 	newPath := filepath.Clean(p)
 	log.Debugf("Config::SetPath(): setting bc.Path=%s", newPath)
-	bc.URL.Path = newPath
+	bc.url.Path = newPath
 	return nil
 }
 
-func (bc *ButlerConfig) GetPath() string {
-	return bc.URL.Path
+func (bc *ButlerConfig) SetMethodOpts(opts MethodOpts) error {
+	log.Debugf("Config::SetMethodOpts(): opts=%#v", opts)
+	bc.MethodOpts = opts
+	return nil
+}
+
+func (bc *ButlerConfig) Path() string {
+	return bc.url.Path
+}
+
+func (bc *ButlerConfig) Host() string {
+	return bc.url.Host
+}
+
+func (bc *ButlerConfig) URL() *url.URL {
+	return bc.url
+}
+
+func (bc *ButlerConfig) Opts() MethodOpts {
+	return bc.MethodOpts
 }
 
 func (bc *ButlerConfig) SetInterval(t int) error {
@@ -122,67 +145,6 @@ func (bc *ButlerConfig) SetTimeout(t int) error {
 	return nil
 }
 
-func (bc *ButlerConfig) SetHTTPAuthType(t string) error {
-	bc.HTTPAuthType = t
-	return nil
-}
-
-func (bc *ButlerConfig) SetHTTPAuthToken(t string) error {
-	bc.HTTPAuthToken = t
-	return nil
-}
-
-func (bc *ButlerConfig) SetHTTPAuthUser(t string) error {
-	bc.HTTPAuthUser = t
-	return nil
-}
-
-func (bc *ButlerConfig) SetRegion(r string) error {
-	bc.S3Region = r
-	return nil
-}
-
-func (bc *ButlerConfig) SetEndpoints(e []string) error {
-	bc.Endpoints = e
-	return nil
-}
-
-func (bc *ButlerConfig) SetRegionAndBucket(r string, b string) error {
-	if bc.Client != nil {
-		method, err := methods.NewS3MethodWithRegionAndBucket(r, b)
-		if err != nil {
-			return err
-		}
-		log.Debugf("ButlerConfig::SetRegionAndBucket(): method=%#v", method)
-		bc.Client.Method = method
-
-	} else {
-		return errors.New("ButlerConfig::SetRegionAndBucket(): bc.Client does not exist")
-	}
-
-	bc.S3Region = r
-	bc.S3Bucket = b
-	return nil
-}
-
-func (bc *ButlerConfig) SetRetries(t int) error {
-	log.Debugf("Config::SetRetries(): setting bc.Retries=%v", t)
-	bc.Retries = t
-	return nil
-}
-
-func (bc *ButlerConfig) SetRetryWaitMin(t int) error {
-	log.Debugf("Config::SetRetryWaitMin(): setting bc.RetryWaitMin=%v", t)
-	bc.RetryWaitMin = t
-	return nil
-}
-
-func (bc *ButlerConfig) SetRetryWaitMax(t int) error {
-	log.Debugf("Config::SetRetryWaitMax(): setting bc.RetryWaitMax=%v", t)
-	bc.RetryWaitMax = t
-	return nil
-}
-
 func (bc *ButlerConfig) SetLogLevel(level log.Level) {
 	log.SetLevel(level)
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
@@ -198,62 +160,10 @@ func (bc *ButlerConfig) Init() error {
 	log.Infof("Config::Init(): initializing butler config.")
 	var err error
 
-	method, err := methods.New(nil, bc.URL.Scheme, nil)
-	if err != nil {
-		if err.Error() == "Generic method handler is not very useful" {
-			log.Errorf("Config::Init(): could not initialize butler config (check if using valid scheme). err=%s", err.Error())
-			return fmt.Errorf("\"%s\" is an invalid config retrieval method.", bc.URL.Scheme)
-
-		} else {
-			log.Errorf("Config::Init(): could not initialize butler config. err=%s", err.Error())
-			return err
-		}
-	}
-	log.Warnf("ButlerConfig::Init() Above \"NewHttpMethod(): could not convert\" warnings may be safely disregarded.")
-
-	client, err := NewConfigClient(bc.URL.Scheme)
+	client, err := NewConfigClient(bc)
 	if err != nil {
 		log.Errorf("Config::Init(): could not initialize butler config. err=%s", err.Error())
 		return err
-	}
-	client.Method = method
-
-	switch bc.URL.Scheme {
-	case "http", "https":
-		client.SetTimeout(bc.Timeout)
-		client.SetRetryMax(bc.Retries)
-		client.SetRetryWaitMin(bc.RetryWaitMin)
-		client.SetRetryWaitMax(bc.RetryWaitMax)
-		// this is a bit hokey
-		m := method.(methods.HTTPMethod)
-		m.AuthType = bc.HTTPAuthType
-		m.AuthToken = bc.HTTPAuthToken
-		m.AuthUser = bc.HTTPAuthUser
-		m.InsecureSkipVerify = bc.InsecureSkipVerify
-		client.Method = m
-	case "s3", "S3":
-		pathSplit := strings.Split(bc.URL.Path, "/")
-		bucket := pathSplit[0]
-		bc.SetRegionAndBucket(bc.S3Region, bucket)
-		client.Method, err = methods.NewS3MethodWithRegionAndBucket(bc.S3Region, bc.URL.Host)
-		if err != nil {
-			return err
-		}
-	case "file":
-		client.Method, err = methods.NewFileMethodWithURL(bc.URL)
-		if err != nil {
-			return err
-		}
-	case "blob":
-		client.Method, err = methods.NewBlobMethodWithAccount(bc.URL.Host)
-		if err != nil {
-			return err
-		}
-	case "etcd":
-		client.Method, err = methods.NewEtcdMethodWithEndpoints(bc.Endpoints, bc.InsecureSkipVerify)
-		if err != nil {
-			return err
-		}
 	}
 
 	bc.Client = client
@@ -265,39 +175,39 @@ func (bc *ButlerConfig) Init() error {
 
 func (bc *ButlerConfig) Handler() error {
 	log.Infof("ButlerConfig::Handler()[count=%v]: entering.", handlerCounter)
-	response, err := bc.Client.Get(bc.URL)
+	response, err := bc.Client.Get(bc.URL())
 
 	if err != nil {
 		log.Errorf("ButlerConfig::Handler()[count=%v]: Cannot retrieve butler configuration. err=%s", handlerCounter, err.Error())
 		log.Errorf("ButlerConfig::Handler()[count=%v]: done.", handlerCounter)
 		handlerCounter++
-		metrics.SetButlerContactVal(metrics.FAILURE, bc.URL.Host, bc.URL.Path)
+		metrics.SetButlerContactVal(metrics.FAILURE, bc.Host(), bc.Path())
 		return err
 	}
 	defer response.GetResponseBody().Close()
 
 	if response.GetResponseStatusCode() != 200 {
-		metrics.SetButlerContactVal(metrics.FAILURE, bc.URL.Host, bc.URL.Path)
-		log.Errorf("ButlerConfig::Handler()[count=%v]: Did not receive 200 response code for %s. code=%d", handlerCounter, bc.URL.String(), response.GetResponseStatusCode())
+		metrics.SetButlerContactVal(metrics.FAILURE, bc.Host(), bc.Path())
+		log.Errorf("ButlerConfig::Handler()[count=%v]: Did not receive 200 response code for %s. code=%d", handlerCounter, bc.URL().String(), response.GetResponseStatusCode())
 		log.Errorf("ButlerConfig::Handler()[count=%v] done.", handlerCounter)
 		handlerCounter++
-		errMsg := fmt.Sprintf("Did not receive 200 response code for %s. code=%d", bc.URL.String(), response.GetResponseStatusCode())
+		errMsg := fmt.Sprintf("Did not receive 200 response code for %s. code=%d", bc.URL().String(), response.GetResponseStatusCode())
 		return errors.New(errMsg)
 	}
 
 	body, err := ioutil.ReadAll(response.GetResponseBody())
 	if err != nil {
-		metrics.SetButlerContactVal(metrics.FAILURE, bc.URL.Host, bc.URL.Path)
-		log.Errorf("ButlerConfig::Handler()[count=%v]: Could not read response body for %s. err=%s", handlerCounter, bc.URL.String(), err)
+		metrics.SetButlerContactVal(metrics.FAILURE, bc.Host(), bc.Path())
+		log.Errorf("ButlerConfig::Handler()[count=%v]: Could not read response body for %s. err=%s", handlerCounter, bc.URL().String(), err)
 		log.Errorf("ButlerConfig::Handler()[count=%v] done.", handlerCounter)
 		handlerCounter++
-		errMsg := fmt.Sprintf("Could not read response body for %s. err=%s", bc.URL.String(), err)
+		errMsg := fmt.Sprintf("Could not read response body for %s. err=%s", bc.URL().String(), err)
 		return errors.New(errMsg)
 	}
 
 	err = ValidateConfig(NewValidateOpts().WithData(body).WithFileName("butler.toml").WithManager("butler-config"))
 	if err != nil {
-		metrics.SetButlerContactVal(metrics.FAILURE, bc.URL.Host, bc.URL.Path)
+		metrics.SetButlerContactVal(metrics.FAILURE, bc.Host(), bc.Path())
 		return err
 	}
 
@@ -307,7 +217,7 @@ func (bc *ButlerConfig) Handler() error {
 			if bc.Config.Globals.ExitOnFailure {
 				log.Fatal(err)
 			} else {
-				metrics.SetButlerContactVal(metrics.FAILURE, bc.URL.Host, bc.URL.Path)
+				metrics.SetButlerContactVal(metrics.FAILURE, bc.Host(), bc.Path())
 				return err
 			}
 		} else {
@@ -322,7 +232,7 @@ func (bc *ButlerConfig) Handler() error {
 			if bc.Config.Globals.ExitOnFailure {
 				log.Fatal(err)
 			} else {
-				metrics.SetButlerContactVal(metrics.FAILURE, bc.URL.Host, bc.URL.Path)
+				metrics.SetButlerContactVal(metrics.FAILURE, bc.Host(), bc.Path())
 				return err
 			}
 		} else {
@@ -360,7 +270,7 @@ func (bc *ButlerConfig) Handler() error {
 			bc.SetCMPrevInterval(bc.GetCMInterval())
 		}
 	}
-	metrics.SetButlerContactVal(metrics.SUCCESS, bc.URL.Host, bc.URL.Path)
+	metrics.SetButlerContactVal(metrics.SUCCESS, bc.Host(), bc.Path())
 	log.Infof("ButlerConfig::Handler()[count=%v]: done.", handlerCounter)
 	handlerCounter++
 	return nil

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -529,10 +529,7 @@ func GetManagerOpts(entry string, bc *ConfigSettings) (*ManagerOpts, error) {
 		MgrOpts.RepoPath = ""
 	}
 
-	switch MgrOpts.Method {
-	case "blob", "file", "http", "https", "s3", "S3", "etcd":
-		break
-	default:
+	if !IsValidScheme(MgrOpts.Method) {
 		msg := fmt.Sprintf("unknown manager.method=%v", MgrOpts.Method)
 		return &ManagerOpts{}, errors.New(msg)
 	}
@@ -741,8 +738,19 @@ func ParseConfig(config []byte) error {
 	return nil
 }
 
-func NewButlerConfig() *ButlerConfig {
-	return &ButlerConfig{FirstRun: true}
+func NewButlerConfig(opts *ButlerConfigOpts) (*ButlerConfig, error) {
+	var (
+		cfg ButlerConfig
+	)
+	cfg.FirstRun = true
+	cfg.InsecureSkipVerify = opts.InsecureSkipVerify
+	cfg.url = opts.URL
+
+	if !IsValidScheme(cfg.Scheme()) {
+		return &cfg, fmt.Errorf("%v is not a supported scheme.", cfg.Scheme())
+	} else {
+		return &cfg, nil
+	}
 }
 
 func NewConfigChanEvent() *ConfigChanEvent {
@@ -754,24 +762,68 @@ func NewConfigChanEvent() *ConfigChanEvent {
 	return &c
 }
 
-func NewConfigClient(scheme string) (*ConfigClient, error) {
+func NewConfigClient(bc *ButlerConfig) (*ConfigClient, error) {
 	var c ConfigClient
-	switch scheme {
+	opts := bc.MethodOpts
+	log.Debugf("opts=%#v", opts)
+	method, err := methods.New(nil, opts.GetScheme(), nil)
+	if err != nil {
+		if err.Error() == "Generic method handler is not very useful" {
+			log.Errorf("Config::Init(): could not initialize butler config (check if using valid scheme). err=%s", err.Error())
+			return &ConfigClient{}, fmt.Errorf("\"%s\" is an invalid config retrieval method.", bc.Scheme())
+
+		} else {
+			log.Errorf("Config::Init(): could not initialize butler config. err=%s", err.Error())
+			return &ConfigClient{}, err
+		}
+	}
+	log.Warnf("ButlerConfig::Init() Above \"NewHttpMethod(): could not convert\" warnings may be safely disregarded.")
+	switch opts.GetScheme() {
 	case "http", "https":
-		c.Scheme = "http"
+		o := opts.(HttpMethodOpts)
+		m := method.(methods.HTTPMethod)
+		m.AuthType = o.HTTPAuthType
+		m.AuthToken = o.HTTPAuthToken
+		m.InsecureSkipVerify = bc.InsecureSkipVerify
+		c.Scheme = o.GetScheme()
 		c.HTTPClient = retryablehttp.NewClient()
 		c.HTTPClient.Logger.SetFlags(0)
 		c.HTTPClient.Logger.SetOutput(ioutil.Discard)
-	case "s3", "S3":
-		c.Scheme = "s3"
+		c.SetTimeout(o.Timeout)
+		c.SetRetryMax(o.Retries)
+		c.SetRetryWaitMax(o.RetryWaitMax)
+		c.SetRetryWaitMin(o.RetryWaitMin)
+		c.Method = m
+	case "s3":
+		o := opts.(S3MethodOpts)
+		c.Scheme = o.GetScheme()
+		c.Method, err = methods.NewS3MethodWithRegionAndBucket(o.Region, bc.Host())
+		if err != nil {
+			return &ConfigClient{}, err
+		}
 	case "file":
-		c.Scheme = "file"
+		o := opts.(FileMethodOpts)
+		c.Scheme = o.GetScheme()
+		c.Method, err = methods.NewFileMethodWithURL(bc.URL())
+		if err != nil {
+			return &ConfigClient{}, err
+		}
 	case "blob":
-		c.Scheme = "blob"
+		o := opts.(BlobMethodOpts)
+		c.Scheme = o.GetScheme()
+		c.Method, err = methods.NewBlobMethodWithAccount(bc.Host())
+		if err != nil {
+			return &ConfigClient{}, err
+		}
 	case "etcd":
-		c.Scheme = "etcd"
+		o := opts.(EtcdMethodOpts)
+		c.Scheme = o.GetScheme()
+		c.Method, err = methods.NewEtcdMethodWithEndpoints(o.Endpoints, bc.InsecureSkipVerify)
+		if err != nil {
+			return &ConfigClient{}, err
+		}
 	default:
-		errMsg := fmt.Sprintf("Unsupported butler config scheme: %s", scheme)
+		errMsg := fmt.Sprintf("Unsupported butler config scheme: %s", opts.GetScheme())
 		return &ConfigClient{}, errors.New(errMsg)
 	}
 	return &c, nil

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -765,7 +765,6 @@ func NewConfigChanEvent() *ConfigChanEvent {
 func NewConfigClient(bc *ButlerConfig) (*ConfigClient, error) {
 	var c ConfigClient
 	opts := bc.MethodOpts
-	log.Debugf("opts=%#v", opts)
 	method, err := methods.New(nil, opts.GetScheme(), nil)
 	if err != nil {
 		if err.Error() == "Generic method handler is not very useful" {
@@ -811,7 +810,7 @@ func NewConfigClient(bc *ButlerConfig) (*ConfigClient, error) {
 	case "blob":
 		o := opts.(BlobMethodOpts)
 		c.Scheme = o.GetScheme()
-		c.Method, err = methods.NewBlobMethodWithAccount(bc.Host())
+		c.Method, err = methods.NewBlobMethodWithAccountAndKey(o.AccountName, o.AccountKey)
 		if err != nil {
 			return &ConfigClient{}, err
 		}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -335,8 +335,7 @@ func (bmo *ManagerOpts) GetAdditionalRemoteConfigFiles() []string {
 
 // Really need to come up with a better method for this.
 func (bmo *ManagerOpts) DownloadConfigFile(file string) *os.File {
-	switch bmo.Method {
-	case "blob", "file", "http", "https", "s3", "S3", "etcd":
+	if IsValidScheme(bmo.Method) {
 		tmpFile, err := ioutil.TempFile("/tmp", "bcmsfile")
 		if err != nil {
 			msg := fmt.Sprintf("ManagerOpts::DownloadConfigFile()[count=%v][manager=%v]: could not create temporary file. err=%v", cmHandlerCounter, bmo.parentManager, err)
@@ -399,7 +398,7 @@ func (bmo *ManagerOpts) DownloadConfigFile(file string) *os.File {
 			return tmpFile
 		}
 		return tmpFile
-	default:
+	} else {
 		return nil
 	}
 }

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -342,7 +342,7 @@ func (bmo *ManagerOpts) DownloadConfigFile(file string) *os.File {
 			log.Fatal(msg)
 		}
 
-		if (bmo.Method == "s3") || (bmo.Method == "S3") {
+		if bmo.Method == "s3" {
 			prefix := bmo.Method + "://"
 			file = strings.TrimPrefix(file, prefix)
 		}

--- a/internal/config/objects.go
+++ b/internal/config/objects.go
@@ -58,7 +58,9 @@ func (o S3MethodOpts) GetScheme() string {
 }
 
 type BlobMethodOpts struct {
-	Scheme string
+	Scheme      string
+	AccountName string
+	AccountKey  string
 }
 
 func (o BlobMethodOpts) GetScheme() string {

--- a/internal/config/objects.go
+++ b/internal/config/objects.go
@@ -20,6 +20,68 @@ var (
 	ConfigCache map[string]map[string][]byte
 )
 
+type MethodOpts interface {
+	GetScheme() string
+}
+
+type FileMethodOpts struct {
+	Scheme string
+}
+
+func (o FileMethodOpts) GetScheme() string {
+	return o.Scheme
+}
+
+type HttpMethodOpts struct {
+	HTTPAuthType  string
+	HTTPAuthToken string
+	HTTPAuthUser  string
+	Retries       int
+	RetryWaitMin  int
+	RetryWaitMax  int
+	Scheme        string
+	Timeout       int
+}
+
+func (o HttpMethodOpts) GetScheme() string {
+	return o.Scheme
+}
+
+type S3MethodOpts struct {
+	Bucket string
+	Region string
+	Scheme string
+}
+
+func (o S3MethodOpts) GetScheme() string {
+	return o.Scheme
+}
+
+type BlobMethodOpts struct {
+	Scheme string
+}
+
+func (o BlobMethodOpts) GetScheme() string {
+	return o.Scheme
+}
+
+type EtcdMethodOpts struct {
+	Endpoints []string
+	Scheme    string
+}
+
+func (o EtcdMethodOpts) GetScheme() string {
+	return o.Scheme
+}
+
+type GenericMethodOpts struct {
+	Scheme string
+}
+
+func (o GenericMethodOpts) GetScheme() string {
+	return "generic"
+}
+
 type TmpFile struct {
 	Name string
 	File string

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package environment
+
+import (
+	. "gopkg.in/check.v1"
+
+	"os"
+	"testing"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type ButlerTestSuite struct {
+}
+
+var _ = Suite(&ButlerTestSuite{})
+
+/*
+func (s *ButlerTestSuite) SetUpSuite(c *C) {
+	//ParseConfigFiles(&Files, FileList)
+}
+*/
+
+func (s *ButlerTestSuite) TestGetVar(c *C) {
+	Test1 := GetVar(1)
+	c.Assert(Test1, Equals, "1")
+
+	Test2 := GetVar("hi")
+	c.Assert(Test2, Equals, "hi")
+
+	Test3 := GetVar("env:DOES_NOT_EXIST")
+	c.Assert(Test3, Equals, "")
+
+	os.Setenv("DOES_EXIST", "YES")
+	Test4 := GetVar("env:DOES_EXIST")
+	c.Assert(Test4, Equals, "YES")
+	os.Unsetenv("DOES_EXIST")
+
+	Test5 := GetVar("what what what")
+	c.Assert(Test5, Equals, "what what what")
+
+	type Foo struct {
+		Bar string
+	}
+	Test6 := GetVar(Foo{})
+	c.Assert(Test6, Equals, "")
+}

--- a/internal/environment/test.sh
+++ b/internal/environment/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2017 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+go test -check.vv -v -coverprofile=./coverage.out
+
+if [ -f ./coverage.out ]; then
+    go tool cover -func ./coverage.out
+    rm -f ./coverage.out
+fi

--- a/internal/methods/blob.go
+++ b/internal/methods/blob.go
@@ -92,8 +92,8 @@ func NewBlobMethodWithAccountAndKey(account string, key string) (Method, error) 
 	}
 	result.StorageKey = environment.GetVar(key)
 
-	os.Setenv("ACCOUNT_KEY", result.StorageKey)
-	os.Setenv("ACCOUNT_NAME", result.StorageAccount)
+	//os.Setenv("ACCOUNT_KEY", result.StorageKey)
+	//os.Setenv("ACCOUNT_NAME", result.StorageAccount)
 
 	client, err = storage.NewBasicClient(result.StorageAccount, result.StorageKey)
 	if err != nil {

--- a/internal/methods/methods.go
+++ b/internal/methods/methods.go
@@ -13,10 +13,10 @@ governing permissions and limitations under the License.
 package methods
 
 import (
+	log "github.com/sirupsen/logrus"
 	"io"
 	"net/url"
 	"strings"
-	//log "github.com/sirupsen/logrus"
 )
 
 type Method interface {
@@ -39,11 +39,12 @@ func (r Response) GetResponseStatusCode() int {
 
 func New(manager *string, method string, entry *string) (Method, error) {
 	method = strings.ToLower(method)
-	//log.Debugf("methods.New() manager=%v method=%v entry=%v", manager, method, entry)
+	// stegen comment this out
+	log.Debugf("methods.New() manager=%v method=%v entry=%v", manager, method, entry)
 	switch method {
 	case "http", "https":
 		return NewHTTPMethod(manager, entry)
-	case "S3", "s3":
+	case "s3":
 		return NewS3Method(manager, entry)
 	case "file":
 		return NewFileMethod(manager, entry)

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -136,8 +136,8 @@ func (m *Monitor) Update(bc *config.ButlerConfig) {
 // configuration options that buter gets started with, and some run time
 // information
 func (m *Monitor) Handler(w http.ResponseWriter, r *http.Request) {
-	mOut := Output{ConfigPath: m.config.GetPath(),
-		ConfigScheme:     m.config.URL.Scheme,
+	mOut := Output{ConfigPath: m.config.Path(),
+		ConfigScheme:     m.config.Scheme(),
 		RetrieveInterval: m.config.Interval,
 		LogLevel:         m.config.GetLogLevel(),
 		ConfigSettings:   *m.config.Config,

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -70,20 +70,31 @@ func (s *ButlerTestSuite) SetUpSuite(c *C) {
 }
 
 func (s *ButlerTestSuite) TestNewMonitor(c *C) {
-	bc := config.NewButlerConfig()
+	u, err := url.Parse("https://localhost")
+	c.Assert(err, IsNil)
+	opts := &config.ButlerConfigOpts{
+		InsecureSkipVerify: true,
+		URL:                u}
+	bc, err := config.NewButlerConfig(opts)
+	c.Assert(err, IsNil)
+	bc.SetMethodOpts(config.HttpMethodOpts{Scheme: bc.Scheme()})
 	m := NewMonitor().WithOpts(&Opts{Config: bc, Version: "1.2.3"})
 	c.Assert(bc, Equals, m.config)
 }
 
 func (s *ButlerTestSuite) TestStartHTTP(c *C) {
 	// have to set some stuff up first
-	bc := config.NewButlerConfig()
-	u := &url.URL{}
+	u, err := url.Parse("https://localhost:58532")
+	c.Assert(err, IsNil)
+	opts := &config.ButlerConfigOpts{
+		InsecureSkipVerify: true,
+		URL:                u}
+	bc, err := config.NewButlerConfig(opts)
+	c.Assert(err, IsNil)
 	bc.Config = config.NewConfigSettings()
 	bc.Config.Globals.HTTPProto = "http"
 	bc.Config.Globals.HTTPPort = 58532
 	bc.Config.Globals.EnableHTTPLog = true
-	bc.URL = u
 	m := NewMonitor().WithOpts(&Opts{Config: bc, Version: "1.2.3"})
 	s.bm = m
 	c.Assert(bc, Equals, m.config)
@@ -115,15 +126,18 @@ func (s *ButlerTestSuite) TestStartHTTPs(c *C) {
 	err = tmpKey.Close()
 	c.Assert(err, IsNil)
 
-	bc := config.NewButlerConfig()
-	u := &url.URL{}
+	u, err := url.Parse("https://localhost")
+	c.Assert(err, IsNil)
+	opts := &config.ButlerConfigOpts{
+		InsecureSkipVerify: true,
+		URL:                u}
+	bc, err := config.NewButlerConfig(opts)
 	bc.Config = config.NewConfigSettings()
 	bc.Config.Globals.HTTPProto = "https"
 	bc.Config.Globals.HTTPPort = 58532
 	bc.Config.Globals.EnableHTTPLog = false
 	bc.Config.Globals.HTTPTLSCert = tmpCert.Name()
 	bc.Config.Globals.HTTPTLSKey = tmpKey.Name()
-	bc.URL = u
 	s.bm.Update(bc)
 	c.Assert(bc, Equals, s.bm.config)
 


### PR DESCRIPTION
There was a lot of repetitive checks happening when differentiating between butler retrieval methods.

Tried to tidy a lot of that up. 

I also tweaked how we do the blob storage. Instead of specifying some BUTLER_ specific environment variables and shoving them across to the right azure blob storage vars, I removed that, since it's silly. Just specify what azure expects.