### PR TITLE
Add caller info (file, function, line) to log output — fixes #28

### DIFF
--- a/cmd/butler/main.go
+++ b/cmd/butler/main.go
@@ -95,6 +95,7 @@ func main() {
 	newConfigLogLevel := environment.GetVar(*configLogLevel)
 	log.SetLevel(SetLogLevel(newConfigLogLevel))
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+	log.SetReportCaller(true)
 
 	if *versionFlag {
 		fmt.Fprintf(os.Stdout, "butler %s\n", version)

--- a/internal/config/handler.go
+++ b/internal/config/handler.go
@@ -140,6 +140,7 @@ func (bc *ButlerConfig) SetTimeout(t int) error {
 func (bc *ButlerConfig) SetLogLevel(level log.Level) {
 	log.SetLevel(level)
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+	log.SetReportCaller(true)
 	bc.LogLevel = level
 	log.Debugf("Config::SetLogLevel(): setting log level to %s", level)
 }


### PR DESCRIPTION
Summary
-------

Adds caller information (package, file, function/method, and line
number) to every log line, addressing the request in 28 for logrus
output verbose enough to debug from directly.

logrus did not support this in 2018 when the issue was filed, but it
has since added `SetReportCaller`, which produces exactly the
package/file/method/line detail requested — no need for the log15
migration floated in the issue.

Change
------

`log.SetReportCaller(true)` added at both places logrus is configured
at runtime:

| File | Function |
|---|---|
| `cmd/butler/main.go` | `main()` |
| `internal/config/handler.go` | `ButlerConfig.SetLogLevel()` |

These are the only two call sites in the codebase that call
`log.SetFormatter`/`log.SetLevel`, so this covers every path that
configures logging, including the `-test` one-shot path (it runs
through the same `main()` setup before branching).

Out of scope: the ~225 individual `log.Debugf`/`log.Infof`/etc. call
sites across the codebase were left untouched. `SetReportCaller`
derives caller info from the runtime call stack, so no per-call-site
changes are needed to get file/function/line on every message.

Related Issue
-------------

Fixes #28

Test Plan
---------

- [x] `go build -o butler.exe ./cmd/butler`
- [x] Ran the built binary against a local `butler.toml` and confirmed
      every log line includes `func=` (package + function/method) and
      `file="...go:line"`, e.g.:
      `func=github.com/adobe/butler/internal/methods.NewHTTPMethod
      file="internal/methods/http.go:92"`

Breaking Changes
-----------------

None — this only adds metadata fields (`func`, `file`) to the existing
log line format. No public method or field signatures changed.
